### PR TITLE
Correct missing character method for seqtype in DNAStringSet

### DIFF
--- a/R/make.consensus.seqs.R
+++ b/R/make.consensus.seqs.R
@@ -72,8 +72,9 @@ make.consensus.seqs <- function(input.folder, forward.suffix, reverse.suffix, mi
                                )
 
     # make the set of consensus sequences
-    consensus.seqs = lapply(consensi, function(x) x$consensus)
-    # Some are null, becuase reads can be removed for e.g. stop codons
+    consensus.seqs = lapply(consensi, function(x) DNAString(x$consensus))
+        # DNAString because DNAStringSet do not work with character sequences
+    # Some are null, because reads can be removed for e.g. stop codons
     consensus.seqs = Filter(Negate(is.null), consensus.seqs)
     consensus.set  = DNAStringSet(consensus.seqs)
 

--- a/R/merge.reads.R
+++ b/R/merge.reads.R
@@ -99,7 +99,7 @@ merge.reads <- function(readset, ref.aa.seq = NULL, minInformation = 0.5, thresh
 
     # get a dendrogram
     dist = DistanceMatrix(aln, correction = "Jukes-Cantor", penalizeGapLetterMatches = FALSE, processors = processors, verbose = FALSE)
-    dend = IdClusters(dist, type = "dendrogram", processors = processors, verbose = FALSE)
+    dend = IdClusters(dist, asDendrogram = TRUE, processors = processors, verbose = FALSE)
 
     # add consensus to alignment
     aln2 = c(aln, DNAStringSet(consensus))


### PR DESCRIPTION
DNAStringSet do not work with character sequences but with (at least) DNAString sequence.